### PR TITLE
saveRelease mit ModelView. 

### DIFF
--- a/src/main/java/de/wit/bibinfo/plattenspieler/controller/ui/ReleasesUiController.java
+++ b/src/main/java/de/wit/bibinfo/plattenspieler/controller/ui/ReleasesUiController.java
@@ -45,10 +45,12 @@ public class ReleasesUiController {
 
 
     @PostMapping({"/saveReleases"})
-    public String saveReleases(ReleasesDto releasesDto, RedirectAttributes redirectAttributes) {
+    public ModelAndView saveReleases(ReleasesDto releasesDto, RedirectAttributes redirectAttributes) {
         releasesService.saveRelease(releasesDto);
-        redirectAttributes.addFlashAttribute("message", "Neuer Release wurde gespeichert");
-        return "redirect:/Releases";
+
+        // TODO Hier fehlt das Setzen des message Attributs für die Alert Message
+        
+        return listReleases();
 
     }
 


### PR DESCRIPTION
Wichtig vorweg: Bitte nur angucken, aber nicht mergen! Deine bestehende Lösung ist die bessere.

Was genau hat denn nicht funktioniert, als du ModelView verwenden wolltest? Ich habe einfach den gleichen Code verwendet wie für die /Releases/ Ansicht. Und damit ich den Code nicht duplizieren muss, rufe ich einfach direkt die Methode auf ;-)

Funktioniert auch, allerdings landet man dann auf _http://localhost:8080/Releases/saveReleases_ und sieht wieder die Listenansicht mit dem neuen Eintrag. Das ist ja irgendwie ungeschickt, weil die Listenansicht ja eigentlich unter /Releases angezeigt wird.
Da finde ich deine Lösung viel charmanter!

Und das Setzen des _message_ Attributes fehlt bei mir auch noch ...